### PR TITLE
Week2 세미나 내용에서 전체 사용자를 List형태로 반환하는 API추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+change2Spring
+java-oop2
+

--- a/banking_OOP/.idea/workspace.xml
+++ b/banking_OOP/.idea/workspace.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="e1ccaa55-4b0f-42b5-8ed7-d743107f54c2" name="변경" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ExternalProjectsData">
+    <projectState path="$PROJECT_DIR$">
+      <ProjectState />
+    </projectState>
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Class" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 3
+}</component>
+  <component name="ProjectId" id="2eadOrJUAu6FYMFvtmNJms6KuEE" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Gradle.BankingOopApplicationTests.contextLoads.executor": "Run",
+    "Gradle.BankingOopApplicationTests.executor": "Run",
+    "Gradle.banking_OOP [:BankingOopApplication.main()].executor": "Run",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "week1",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/home/kihoon/Desktop/spring/rlarlgnszx/banking_OOP",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "reference.settings.ide.settings.uml",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RecentsManager">
+    <key name="CreateClassDialog.RecentsKey">
+      <recent name="server.sopt.banking_oop.object" />
+    </key>
+  </component>
+  <component name="RunManager" selected="애플리케이션.BankingOopApplication">
+    <configuration name="BankingOopApplication" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
+      <option name="MAIN_CLASS_NAME" value="server.sopt.banking_oop.BankingOopApplication" />
+      <module name="banking_OOP.main" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="server.sopt.banking_oop.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="BankingOopApplicationTests" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;server.sopt.banking_oop.BankingOopApplicationTests&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="BankingOopApplicationTests.contextLoads" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;server.sopt.banking_oop.BankingOopApplicationTests.contextLoads&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="BankingOopApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+      <module name="banking_OOP.main" />
+      <option name="SPRING_BOOT_MAIN_CLASS" value="server.sopt.banking_oop.BankingOopApplication" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Gradle.BankingOopApplicationTests" />
+        <item itemvalue="Gradle.BankingOopApplicationTests.contextLoads" />
+        <item itemvalue="애플리케이션.BankingOopApplication" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="애플리케이션 수준" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="디폴트 작업">
+      <changelist id="e1ccaa55-4b0f-42b5-8ed7-d743107f54c2" name="변경" comment="" />
+      <created>1712146596149</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1712146596149</updated>
+      <workItem from="1712146597295" duration="2342000" />
+      <workItem from="1712157270348" duration="4507000" />
+      <workItem from="1712207511167" duration="12847000" />
+      <workItem from="1712225741006" duration="5384000" />
+      <workItem from="1712289376104" duration="7858000" />
+      <workItem from="1712492886427" duration="1488000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="week1" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/week1/banking_OOP/src/main/java/server/sopt/banking_oop/service/ServiceProduct.java
+++ b/week1/banking_OOP/src/main/java/server/sopt/banking_oop/service/ServiceProduct.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 @Getter
 @Setter
 //@NoArgsConstructor
-public abstract  class ServiceProduct {
+public abstract class ServiceProduct {
     public abstract void deposit(Person person,Double money) throws IOException;
 
     public abstract void savings(Person person, Double money) throws IOException;

--- a/week2/src/main/java/server/sopt/week2/controller/MemberController.java
+++ b/week2/src/main/java/server/sopt/week2/controller/MemberController.java
@@ -8,25 +8,36 @@ import server.sopt.week2.dto.MemberFindDto;
 import server.sopt.week2.service.MemberService;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
 public class MemberController {
     private final MemberService memberService;
+
     @PostMapping
-    public ResponseEntity createMember(@RequestBody MemberCreateDto memberCreateDto){
+    public ResponseEntity createMember(@RequestBody MemberCreateDto memberCreateDto) {
         return ResponseEntity.created(URI.create(memberService.createMember(memberCreateDto))).build();
     }
+
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberFindDto> getMemberById(
             @PathVariable Long memberId
     ) {
         return ResponseEntity.ok(memberService.getMemberById(memberId));
     }
+
+
     @DeleteMapping("/{memberId}")
     public ResponseEntity deleteMember(@PathVariable Long memberId) {
         memberService.deleteMember(memberId);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping()
+    public List<MemberFindDto> getAllMember(){
+        return memberService.getAllMember();
+    }
+
 }

--- a/week2/src/main/java/server/sopt/week2/service/MemberService.java
+++ b/week2/src/main/java/server/sopt/week2/service/MemberService.java
@@ -8,6 +8,9 @@ import server.sopt.week2.dto.MemberCreateDto;
 import server.sopt.week2.dto.MemberFindDto;
 import server.sopt.week2.repo.MemberRepository;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -24,6 +27,12 @@ public class MemberService {
 
     public MemberFindDto getMemberById(Long memberId) {
         return MemberFindDto.of(findMemberById(memberId));
+    }
+
+    public List<MemberFindDto> getAllMember() {
+        return memberRepository.findAll()
+                .stream().map(MemberFindDto::of)
+                .collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
### 1.Controller에 MemberFindDto형태의 List를 반환하는 메소드 추가 

![image](https://github.com/NOW-SOPT-SERVER/rlarlgnszx/assets/40743105/ee18a9a0-c491-4a90-ac7f-9223173418b4)

### 2.Service쪽에서 JPARepository에 이미 구현된 get에 관련된 다양한 메소드중 전체를 그저 보여줄수 있는 findAll method를 통해서 기존의 MemberFindDto의 of method 생성자로 전체 얻은 Dto를 List형태로 반환 
![image](https://github.com/NOW-SOPT-SERVER/rlarlgnszx/assets/40743105/b64c17b9-2493-4102-8265-9cd12fc109d1)
- 등록된 사용자들
![image](https://github.com/NOW-SOPT-SERVER/rlarlgnszx/assets/40743105/d86a131e-de85-4d2d-b161-a6abae2badf0)
- 사용자들 List get
![image](https://github.com/NOW-SOPT-SERVER/rlarlgnszx/assets/40743105/dadf3579-87f9-4d9a-ba56-9e526313d054)

### Question 
- [ ] 이미 존재하는 DTO를 활용하는것보다 새로운 DTO를 만드는것이 나을까?? 
- [ ] MemberDTO에서 가져오는 View와 MemberListDTO를 만든다면 결국에 같은 부분을 보여주는 View?가 아닐까? 라는 생각
- [ ] Stream은 다들 쓴다고 하는데 혹시 좋은 이점들이 있으면 알려주십사 합니다...




만든 API List

1. POST 
 - Member 생성하는 API

```java
  @PostMapping
    public ResponseEntity createMember(@RequestBody MemberCreateDto memberCreateDto) {
        return ResponseEntity.created(URI.create(memberService.createMember(memberCreateDto))).build();
    }
```
2. GET
 - 특정 멤머 조회 API
```java
@GetMapping("/{memberId}")
    public ResponseEntity<MemberFindDto> getMemberById(
            @PathVariable Long memberId
    ) {
        return ResponseEntity.ok(memberService.getMemberById(memberId));
    }

```

3. Delete
 - 특정 멤머 조회 API
```java
 @DeleteMapping("/{memberId}")
    public ResponseEntity deleteMember(@PathVariable Long memberId) {
        memberService.deleteMember(memberId);
        return ResponseEntity.noContent().build();
    }
```

4. GET
 - 멤버 전체 조회 API
```java
 @GetMapping()
    public List<MemberFindDto> getAllMember(){
        return memberService.getAllMember();
    }

```

### 멤버 API 명세서
https://crystalline-paper-4ea.notion.site/API-50c7c51dc9fe4f11bb19327bb20264e0